### PR TITLE
Add basic auth UI with FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# football
+# Football Auth Demo
+
+## Setup
+
+1. `poetry install`
+2. `npm install tailwindcss`
+3. `npm run build:css`
+4. `poetry run uvicorn app.main:app --reload`
+
+Visit `http://localhost:8000/auth/login` to view the login form. Incorrect credentials should display an error in place without page reload; correct credentials redirect back to home.

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,3 +1,30 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Form, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from app.jinja2_env import templates
+from .schemas import UserLogin
 
 auth_router = APIRouter()
+
+
+def login_form(
+    username: str = Form(...),
+    password: str = Form(...),
+) -> UserLogin:
+    return UserLogin(username=username, password=password)
+
+
+@auth_router.get("/login", response_class=HTMLResponse)
+async def login_get(request: Request):
+    return templates.TemplateResponse("auth/login.html", {"request": request})
+
+
+@auth_router.post("/login")
+async def login_post(form: UserLogin = Depends(login_form)):
+    if form.username == "admin" and form.password == "secret":
+        return RedirectResponse("/", status_code=status.HTTP_303_SEE_OTHER)
+    return HTMLResponse(
+        '<p class="text-red-500">Invalid credentials</p>',
+        status_code=status.HTTP_200_OK,
+    )
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,14 @@
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+
+from app.auth.routes import auth_router
+
 
 app = FastAPI()
 
-# Routers will be mounted here in the future
+app.include_router(auth_router, prefix="/auth")
+
+
+@app.get("/", include_in_schema=False)
+async def root():
+    return RedirectResponse(url="/auth/login")

--- a/app/static/css/tailwind.css
+++ b/app/static/css/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/static/js/alpine.js
+++ b/app/static/js/alpine.js
@@ -1,0 +1,3 @@
+// Placeholder for Alpine.js
+// This file can be replaced with a local copy or CDN import.
+// <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/app/static/tailwind.config.js
+++ b/app/static/tailwind.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ["../templates/**/*.html"],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div id="flash"></div>
+<div class="max-w-md mx-auto p-6 bg-white rounded shadow mt-10">
+    <form method="post" action="" hx-post="/auth/login" hx-target="#flash" hx-swap="innerHTML" x-data="{ show: false }">
+        <div class="mb-4">
+            <label class="block text-gray-700">Username</label>
+            <input type="text" name="username" class="w-full border rounded p-2" required>
+        </div>
+        <div class="mb-4">
+            <label class="block text-gray-700">Password</label>
+            <input :type="show ? 'text' : 'password'" name="password" class="w-full border rounded p-2" required>
+            <label class="text-sm"><input type="checkbox" @change="show = !show"> Show Password</label>
+        </div>
+        <div>
+            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Login</button>
+        </div>
+    </form>
+</div>
+{% endblock %}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Auth App{% endblock %}</title>
+    <link href="/static/css/tailwind.css" rel="stylesheet">
+    <script src="/static/js/alpine.js"></script>
+</head>
+<body class="bg-gray-100">
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build:css": "tailwindcss -i ./app/static/css/input.css -o ./app/static/css/tailwind.css",
-    "watch:css": "tailwindcss -i ./app/static/css/input.css -o ./app/static/css/tailwind.css --watch"
+    "build:css": "tailwindcss -i ./app/static/css/tailwind.css -o ./app/static/css/output.css --minify"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- implement basic auth router and mount on `/auth`
- redirect root path to login
- scaffold base and login templates
- set up Tailwind and Alpine placeholders
- document setup steps in README

## Testing
- `npm run build:css` *(fails: tailwindcss not found)*
- `poetry run uvicorn app.main:app --reload` *(fails: pyenv missing)*

------
https://chatgpt.com/codex/tasks/task_e_686991713d0c83318b4adaae40431cad