### PR TITLE
Add auth endpoint tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ jinja2 = "3.1.6"
 pydantic = "2.11.7"
 python-multipart = "0.0.20"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.main import app
+
+client = TestClient(app)
+
+def test_login_get():
+    response = client.get("/auth/login")
+    assert response.status_code == 200
+
+
+def test_login_post_valid():
+    response = client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "secret"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers.get("location") == "/"
+
+
+def test_login_post_invalid():
+    response = client.post(
+        "/auth/login",
+        data={"username": "user", "password": "wrong"},
+    )
+    assert response.status_code == 200
+    assert "Invalid credentials" in response.text


### PR DESCRIPTION
## Summary
- add pytest-based auth tests
- configure pyproject with pytest dev dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686994c241988331aca9475d04fa420b