### PR TITLE
Add simple homepage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
+from fastapi.responses import HTMLResponse
 
 from app.auth.routes import auth_router
+from app.jinja2_env import templates
 
 
 app = FastAPI()
@@ -10,5 +12,5 @@ app.include_router(auth_router, prefix="/auth")
 
 
 @app.get("/", include_in_schema=False)
-async def root():
-    return RedirectResponse(url="/auth/login")
+async def root(request: Request):
+    return templates.TemplateResponse("home.html", {"request": request})

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h1>Hello this is homepage</h1>
+{% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,3 +30,9 @@ def test_login_post_invalid():
     )
     assert response.status_code == 200
     assert "Invalid credentials" in response.text
+
+
+def test_homepage_get():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Hello this is homepage" in response.text


### PR DESCRIPTION
## Summary
- implement `/` to serve a template instead of redirecting
- create `home.html` template with greeting
- test homepage route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a73d1b5148331acfba22e3817b5e1