### PR TITLE
Switch to config.ini for Cognito settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@
 2. `npm install tailwindcss`
 3. `npm run build:css`
 4. `poetry run uvicorn app.main:app --reload`
+5. Adjust settings in `config.ini` if your Cognito details differ.
 
 Visit `http://localhost:8000/auth/login` to view the login form. Incorrect credentials should display an error in place without page reload; correct credentials redirect back to home.

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,11 +1,7 @@
 from fastapi import APIRouter, status
 from fastapi.responses import RedirectResponse
 
-COGNITO_AUTH_URL = (
-    "https://eu-west-2wwv3xqgys.auth.eu-west-2.amazoncognito.com/login?"
-    "client_id=68al97tfenubl3tc3k4fnii8ob&response_type=code&"
-    "scope=email+openid+phone&redirect_uri=http%3A%2F%2Flocalhost%3A8000"
-)
+from app.config import COGNITO_AUTH_URL
 
 auth_router = APIRouter()
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,16 @@
+from configparser import ConfigParser
+from pathlib import Path
+from urllib.parse import quote_plus
+
+_config = ConfigParser()
+_config.read(Path(__file__).resolve().parent.parent / "config.ini")
+
+COGNITO_AUTH_URL_BASE = _config.get("cognito", "auth_url_base")
+COGNITO_CLIENT_ID = _config.get("cognito", "client_id")
+COGNITO_SCOPE = _config.get("cognito", "scope")
+COGNITO_REDIRECT_URI = _config.get("cognito", "redirect_uri")
+
+COGNITO_AUTH_URL = (
+    f"{COGNITO_AUTH_URL_BASE}?client_id={COGNITO_CLIENT_ID}&response_type=code&"
+    f"scope={COGNITO_SCOPE}&redirect_uri={quote_plus(COGNITO_REDIRECT_URI)}"
+)

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,8 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
-from app.auth.routes import auth_router, COGNITO_AUTH_URL
+from app.auth.routes import auth_router
+from app.config import COGNITO_AUTH_URL
 from app.jinja2_env import templates
 
 # Determine this file’s parent dir (i.e. the "app/" folder)

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,5 @@
+[cognito]
+auth_url_base = https://eu-west-2wwv3xqgys.auth.eu-west-2.amazoncognito.com/login
+client_id = 68al97tfenubl3tc3k4fnii8ob
+scope = email+openid+phone
+redirect_uri = http://localhost:8000

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from app.main import app
+from app.config import COGNITO_AUTH_URL
 
 client = TestClient(app)
 
@@ -11,19 +12,13 @@ client = TestClient(app)
 def test_login_get():
     response = client.get("/auth/login", follow_redirects=False)
     assert response.status_code == 307
-    assert (
-        response.headers.get("location")
-        == "https://eu-west-2wwv3xqgys.auth.eu-west-2.amazoncognito.com/login?client_id=68al97tfenubl3tc3k4fnii8ob&response_type=code&scope=email+openid+phone&redirect_uri=http%3A%2F%2Flocalhost%3A8000"
-    )
+    assert response.headers.get("location") == COGNITO_AUTH_URL
 
 
 def test_login_post_redirect():
     response = client.post("/auth/login", follow_redirects=False)
     assert response.status_code == 307
-    assert (
-        response.headers.get("location")
-        == "https://eu-west-2wwv3xqgys.auth.eu-west-2.amazoncognito.com/login?client_id=68al97tfenubl3tc3k4fnii8ob&response_type=code&scope=email+openid+phone&redirect_uri=http%3A%2F%2Flocalhost%3A8000"
-    )
+    assert response.headers.get("location") == COGNITO_AUTH_URL
 
 
 def test_homepage_get():
@@ -35,7 +30,4 @@ def test_homepage_get():
 def test_homepage_redirect_for_new_user():
     response = client.get("/", follow_redirects=False)
     assert response.status_code == 307
-    assert (
-        response.headers.get("location")
-        == "https://eu-west-2wwv3xqgys.auth.eu-west-2.amazoncognito.com/login?client_id=68al97tfenubl3tc3k4fnii8ob&response_type=code&scope=email+openid+phone&redirect_uri=http%3A%2F%2Flocalhost%3A8000"
-    )
+    assert response.headers.get("location") == COGNITO_AUTH_URL


### PR DESCRIPTION
## Summary
- centralize Cognito config in `config.ini`
- load settings using `configparser`
- update auth routes and app to use the config module
- update tests to read Cognito URL from config
- document configuration step in README

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb7ee4b6483318b6b5f24f560a3ba