### PR TITLE
Improve auth demo styling and documentation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for the Football authentication demo."""

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication package providing Cognito integration."""

--- a/app/auth/cognito.py
+++ b/app/auth/cognito.py
@@ -1,4 +1,8 @@
+"""Utility functions for interacting with AWS Cognito."""
+
 import os
+from typing import Any, Dict, Optional
+
 import boto3
 from botocore.exceptions import ClientError
 
@@ -9,9 +13,11 @@ COGNITO_CLIENT_ID = os.getenv("COGNITO_CLIENT_ID")
 client = boto3.client("cognito-idp", region_name=AWS_REGION)
 
 
-def authenticate_user(username: str, password: str):
-    """Attempt ADMIN_NO_SRP_AUTH against Cognito. Returns AuthenticationResult dict
-    or None on failure."""
+def authenticate_user(username: str, password: str) -> Optional[Dict[str, Any]]:
+    """Attempt ADMIN_NO_SRP_AUTH against Cognito.
+
+    Returns the ``AuthenticationResult`` dictionary or ``None`` on failure.
+    """
     try:
         resp = client.initiate_auth(
             AuthFlow="ADMIN_NO_SRP_AUTH",

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -1,7 +1,11 @@
+"""Authentication dependencies used across the application."""
+
 import os
+from typing import Any, Dict
+
 import requests
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import jwk, jwt
 
 AWS_REGION = os.getenv("AWS_REGION")
@@ -14,9 +18,14 @@ jwks = requests.get(jwks_url).json()
 security = HTTPBearer()
 
 
-def get_current_user(token=Depends(security)):
-    """Validates the Cognito JWT from Authorization header or cookie.
-    Returns the decoded JWT payload or raises 401."""
+def get_current_user(
+    token: HTTPAuthorizationCredentials = Depends(security),
+) -> Dict[str, Any]:
+    """Validate the Cognito JWT from Authorization header or cookie.
+
+    Returns the decoded JWT payload or raises ``HTTPException`` if the
+    token is invalid or expired.
+    """
     credentials = token.credentials
     try:
         header = jwt.get_unverified_header(credentials)

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,5 +1,9 @@
-from fastapi import APIRouter, Form, Depends, Response, status, Request
-from fastapi.responses import RedirectResponse
+"""HTTP route handlers for authentication endpoints."""
+
+from typing import Union
+
+from fastapi import APIRouter, Form, Response, status, Request
+from fastapi.responses import RedirectResponse, Response as FastAPIResponse
 
 from app.jinja2_env import templates
 from app.auth.cognito import authenticate_user
@@ -8,7 +12,8 @@ auth_router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @auth_router.get("/login")
-async def get_login(request: Request):
+async def get_login(request: Request) -> FastAPIResponse:
+    """Render the login form."""
     return templates.TemplateResponse(request, "auth/login.html")
 
 
@@ -17,7 +22,8 @@ async def post_login(
     response: Response,
     username: str = Form(...),
     password: str = Form(...),
-):
+) -> Union[FastAPIResponse, Response]:
+    """Process the login form submission."""
     auth = authenticate_user(username, password)
     if not auth:
         return Response(

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -1,3 +1,5 @@
+"""Pydantic models used by the authentication routes."""
+
 from pydantic import BaseModel
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,5 @@
+"""Configuration loader for AWS Cognito settings."""
+
 from configparser import ConfigParser
 from pathlib import Path
 from urllib.parse import quote_plus

--- a/app/jinja2_env.py
+++ b/app/jinja2_env.py
@@ -1,3 +1,5 @@
+"""Jinja2 environment configuration for HTML templates."""
+
 from pathlib import Path
 from fastapi.templating import Jinja2Templates
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
+"""Application entry point for the FastAPI authentication demo."""
+
 from pathlib import Path
 
 from fastapi import FastAPI, Request, status
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from app.auth.routes import auth_router
@@ -25,7 +27,7 @@ app.include_router(auth_router)
 
 
 @app.get("/", include_in_schema=False)
-async def root(request: Request):
+async def root(request: Request) -> Response:
     """
     If the user has an Authorization header or a Cognito 'code' param,
     render home.html; otherwise kick them to the Cognito login URL.

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,7 @@
     <link href="/static/css/tailwind.css" rel="stylesheet">
     <script src="/static/js/alpine.js"></script>
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-100 {% block body_class %}{% endblock %}">
     {% block content %}{% endblock %}
 </body>
 </html>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block body_class %}bg-green-500{% endblock %}
+
 {% block content %}
 <h1>Hello this is homepage</h1>
 {% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,7 +13,6 @@ os.environ.setdefault("COGNITO_CLIENT_ID", "dummy_client")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from app.main import app
-from app.auth import cognito
 from app.config import COGNITO_AUTH_URL
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- support custom body class in base template
- apply green background on home page
- clean up imports in auth routes and tests
- document and type hints across modules

## Testing
- `poetry run pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_686d0342eee88331b440457a5d111b49