### PR TITLE
Fix DeprecationWarning in auth tests

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -84,9 +84,11 @@ def test_homepage_cookie_login(monkeypatch):
     cookie = login_resp.cookies.get("access_token")
     assert cookie == "abc"
 
-    response = client.get("/", cookies={"access_token": cookie})
+    client.cookies.set("access_token", cookie)
+    response = client.get("/")
     assert response.status_code == 200
     assert "u1" in response.text
+    client.cookies.clear()
 
 
 def test_get_current_user_valid(monkeypatch):


### PR DESCRIPTION
## Summary
- update `test_homepage_cookie_login` to use the client's cookie jar
- clear the cookie jar after the test

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d26f839c48331b9c78157b0e7404c