### PR TITLE
Improve setup steps and remove test warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ This repository uses **Poetry** for Python dependencies and **npm** for front-en
    ```
    This script installs Python (via Poetry) and Node requirements.
 
+   After setup, copy the example environment file:
+   ```bash
+   cp .env.template .env
+   ```
+   Adjust values as needed for your Cognito configuration.
+
 2. **Run tests and linters** before committing:
    ```bash
    poetry run ruff check .

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -127,7 +127,8 @@ def test_callback_flow(monkeypatch):
     cookie = resp.cookies.get("access_token")
     assert cookie == "jwt1"
 
-    resp2 = client.get("/", cookies={"access_token": cookie})
+    client.cookies.set("access_token", cookie)
+    resp2 = client.get("/")
     assert resp2.status_code == 200
     assert "u1" in resp2.text
 


### PR DESCRIPTION
## Summary
- update AGENTS instructions with `.env` copy step for easier setup
- silence deprecated cookie usage in tests

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d29605bd08331bfe1cc066085b844