### PR TITLE
Fix missing client id in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ A fully server-rendered, Alpine/HTMX-enhanced UI served by S3/CloudFront for max
 Your FastAPI code running in a Lambda container, scaling to zero when idle.
 
 ## Setup
-run setup.sh (poetry will be run according to the setup.sh script)
-Copy `.env.template` to `.env` and adjust the values for your Cognito setup.
+Run `setup.sh` to install Poetry and Node dependencies.
+Copy `.env.template` to `.env` and replace the placeholder Cognito values with your own.
+At a minimum `COGNITO_CLIENT_ID` must be provided or the application will not start.
 
 ## Testing
 poetry run pytest

--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,9 @@ COGNITO_AUTH_URL_BASE = os.getenv(
     "COGNITO_AUTH_URL_BASE",
     "https://example.auth.eu-west-2.amazoncognito.com/login",
 )
-COGNITO_CLIENT_ID = os.getenv("COGNITO_CLIENT_ID", "dummy_client")
+COGNITO_CLIENT_ID = os.getenv("COGNITO_CLIENT_ID")
+if not COGNITO_CLIENT_ID:
+    raise RuntimeError("Missing COGNITO_CLIENT_ID environment variable")
 COGNITO_SCOPE = os.getenv("COGNITO_SCOPE", "email+openid+phone")
 COGNITO_REDIRECT_URI = os.getenv("COGNITO_REDIRECT_URI", "http://localhost:8000/")
 


### PR DESCRIPTION
## Summary
- require `COGNITO_CLIENT_ID` to be set when building the Cognito login URL
- clarify setup instructions about the required environment variable

## Testing
- `./setup.sh`
- `poetry run ruff check .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_686d2ab8250083318de3fd4b78df2baa