### PR TITLE
Fix env loading order in main app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,8 +7,8 @@ from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPAuthorizationCredentials
 
-from app.auth.routes import auth_router
 import app.core.config  # noqa: F401  # Ensure .env is loaded on startup
+from app.auth.routes import auth_router
 from app.config import COGNITO_AUTH_URL
 from app.jinja2_env import templates
 from app.auth.cognito import exchange_code_for_tokens


### PR DESCRIPTION
## Summary
- ensure `.env` is loaded before importing auth routes

## Testing
- `poetry run ruff check .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_686d2eb7f2f48331a8913551f5cb0cf9