### PR TITLE
Fix local cookie handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.auth.routes import auth_router
 from app.config import COGNITO_AUTH_URL
 from app.jinja2_env import templates
 from app.auth.cognito import exchange_code_for_tokens
+from app.core.config import STAGE
 
 # Determine this file’s parent dir (i.e. the "app/" folder)
 BASE_DIR = Path(__file__).parent
@@ -45,7 +46,7 @@ async def root(request: Request) -> Response:
             key="access_token",
             value=id_token,
             httponly=True,
-            secure=True,
+            secure=(STAGE != "local"),
         )
         return redirect
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -126,6 +126,9 @@ def test_callback_flow(monkeypatch):
     assert resp.headers["location"] == "/"
     cookie = resp.cookies.get("access_token")
     assert cookie == "jwt1"
+    # Cookie should not include Secure flag when STAGE is local
+    set_cookie_header = resp.headers.get("set-cookie", "")
+    assert "Secure" not in set_cookie_header
 
     client.cookies.set("access_token", cookie)
     resp2 = client.get("/")


### PR DESCRIPTION
## Summary
- make OAuth callback cookie secure only in non-local stages
- assert callback cookie doesn't include Secure flag in local tests

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2fe10fa88331b97fd530690844ac