### PR TITLE
Fix secure cookie logic for OAuth tokens

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -2,12 +2,11 @@
 
 from typing import Union
 
-from fastapi import APIRouter, Form, Response, status, Request
+from fastapi import APIRouter, Form, Request, Response, status
 from fastapi.responses import RedirectResponse, Response as FastAPIResponse
 
 from app.jinja2_env import templates
 from app.auth.cognito import authenticate_user
-from app.core.config import STAGE
 
 auth_router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -20,7 +19,7 @@ async def get_login(request: Request) -> FastAPIResponse:
 
 @auth_router.post("/login")
 async def post_login(
-    response: Response,
+    request: Request,
     username: str = Form(...),
     password: str = Form(...),
 ) -> Union[FastAPIResponse, Response]:
@@ -36,6 +35,6 @@ async def post_login(
         key="access_token",
         value=auth["IdToken"],
         httponly=True,
-        secure=(STAGE != "local"),
+        secure=(request.url.scheme == "https"),
     )
     return redirect

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,6 @@ from app.auth.routes import auth_router
 from app.config import COGNITO_AUTH_URL
 from app.jinja2_env import templates
 from app.auth.cognito import exchange_code_for_tokens
-from app.core.config import STAGE
 
 # Determine this file’s parent dir (i.e. the "app/" folder)
 BASE_DIR = Path(__file__).parent
@@ -46,7 +45,7 @@ async def root(request: Request) -> Response:
             key="access_token",
             value=id_token,
             httponly=True,
-            secure=(STAGE != "local"),
+            secure=(request.url.scheme == "https"),
         )
         return redirect
 


### PR DESCRIPTION
## Summary
- set OAuth cookie security using incoming request scheme
- adjust login route to accept Request and mirror same security logic

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d35a38be88331be9b4ef24b09cbec