### PR TITLE
Implement central logging module

### DIFF
--- a/app/auth/cognito.py
+++ b/app/auth/cognito.py
@@ -6,6 +6,7 @@ import logging
 
 import requests
 from requests.auth import HTTPBasicAuth
+from requests.exceptions import HTTPError, RequestException
 
 from app.config import COGNITO_AUTH_URL_BASE, COGNITO_REDIRECT_URI
 from app.core.config import COGNITO_APP_CLIENT_ID, COGNITO_APP_CLIENT_SECRET
@@ -20,13 +21,6 @@ COGNITO_CLIENT_ID = os.getenv("COGNITO_CLIENT_ID")
 client = boto3.client("cognito-idp", region_name=AWS_REGION)
 
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
-    )
-    logger.addHandler(handler)
-logger.setLevel(logging.DEBUG)
 
 
 def authenticate_user(username: str, password: str) -> Optional[Dict[str, Any]]:
@@ -100,7 +94,6 @@ def exchange_code_for_tokens(code: str) -> Dict[str, Any]:
         logger.error("RequestException during token exchange: %s", req_err, exc_info=True)
         raise
 
-    except Exception as err:
+    except Exception:
         # Catch any other unexpected errors
-        logger.error("Unexpected error in exchange_code_for_tokens", exc_info=True)
-        raise
+        logger.error("Unexpected error in exchange_code_for_tokens", exc_info=True)        raise

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict
 
+import logging
 import requests
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -19,7 +20,10 @@ jwks_url = (
     f"https://cognito-idp.{COGNITO_REGION}.amazonaws.com/"
     f"{COGNITO_USER_POOL_ID}/.well-known/jwks.json"
 )
-print("JWKS URL →", jwks_url)
+
+logger = logging.getLogger(__name__)
+logger.debug("JWKS URL → %s", jwks_url)
+
 jwks = requests.get(jwks_url).json()
 
 security = HTTPBearer()

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,0 +1,24 @@
+"""Central logging configuration for the application."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+
+def configure_logging() -> None:
+    """Configure the root logger.
+
+    The log level can be controlled via the ``LOG_LEVEL`` environment variable
+    and currently supports ``INFO`` and ``DEBUG``. Any other value defaults to
+    ``INFO``.
+    """
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    if level_name not in {"INFO", "DEBUG"}:
+        level_name = "INFO"
+
+    logging.basicConfig(
+        level=getattr(logging, level_name, logging.INFO),
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from app.logger import configure_logging
 from fastapi import FastAPI, Request, status
 from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -12,6 +13,8 @@ from app.auth.routes import auth_router
 from app.config import COGNITO_AUTH_URL
 from app.jinja2_env import templates
 from app.auth.cognito import exchange_code_for_tokens
+
+configure_logging()
 
 # Determine this file’s parent dir (i.e. the "app/" folder)
 BASE_DIR = Path(__file__).parent

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -98,8 +98,12 @@ def test_homepage_cookie_login(monkeypatch):
 
 
 def test_callback_flow(monkeypatch):
-    def fake_post(url, data=None, auth=None, headers=None):
+    def fake_post(url, data=None, auth=None, headers=None, **kwargs):
         class Resp:
+            status_code = 200
+            headers = {}
+            text = "{}"
+
             def raise_for_status(self_inner):
                 pass
 


### PR DESCRIPTION
## Summary
- add reusable logging configurator
- integrate central logging in main app
- remove ad-hoc logging setup in cognito module and dependencies
- adjust tests for new logging

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e785da174833181ce251e6722347e