### PR TITLE
Fix logging error handling for token exchange

### DIFF
--- a/app/auth/cognito.py
+++ b/app/auth/cognito.py
@@ -95,5 +95,8 @@ def exchange_code_for_tokens(code: str) -> Dict[str, Any]:
         raise
 
     except Exception:
-        # Catch any other unexpected errors
-        logger.error("Unexpected error in exchange_code_for_tokens", exc_info=True)        raise
+        # Catch any other unexpected errors        logger.error(
+            "Unexpected error in exchange_code_for_tokens",
+            exc_info=True,
+        )
+        raise


### PR DESCRIPTION
## Summary
- fix truncated logging call in auth.cognito
- keep existing logging configuration for INFO and DEBUG levels

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e7c652594833195a4819b7a4c2f01