### PR TITLE
Fix Cognito at_hash error

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -38,7 +38,7 @@ async def post_login(
     redirect = RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
     redirect.set_cookie(
         key="access_token",
-        value=auth["IdToken"],
+        value=auth.get("AccessToken") or auth.get("IdToken"),
         httponly=True,
         secure=(request.url.scheme == "https"),
     )

--- a/app/main.py
+++ b/app/main.py
@@ -53,11 +53,11 @@ async def root(request: Request) -> Response:
 
     if code:
         tokens = exchange_code_for_tokens(code)
-        id_token = tokens.get("id_token") or tokens.get("access_token")
+        access_token = tokens.get("access_token") or tokens.get("id_token")
         redirect = RedirectResponse("/", status_code=status.HTTP_303_SEE_OTHER)
         redirect.set_cookie(
             key="access_token",
-            value=id_token,
+            value=access_token,
             httponly=True,
             secure=(request.url.scheme == "https"),
         )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -35,7 +35,7 @@ def test_login_post_invalid(monkeypatch):
 
 
 def test_login_post_success(monkeypatch):
-    monkeypatch.setattr("app.auth.routes.authenticate_user", lambda u, p: {"IdToken": "abc"})
+    monkeypatch.setattr("app.auth.routes.authenticate_user", lambda u, p: {"AccessToken": "abc"})
     response = client.post("/auth/login", data={"username": "good", "password": "pass"}, follow_redirects=False)
     assert response.status_code == 303
     assert response.headers.get("location") == "/"
@@ -77,7 +77,7 @@ def test_homepage_cookie_login(monkeypatch):
 
     monkeypatch.setattr("requests.get", fake_get)
     monkeypatch.setattr(
-        "app.auth.routes.authenticate_user", lambda u, p: {"IdToken": "abc"}
+        "app.auth.routes.authenticate_user", lambda u, p: {"AccessToken": "abc"}
     )
     monkeypatch.setattr(
         "app.auth.dependencies.get_current_user", lambda token=None: {"sub": "u1"}


### PR DESCRIPTION
## Summary
- store Cognito access token in cookie after login and callback
- adjust tests to expect access token

## Testing
- `poetry run ruff check .`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e93e834d08331b4b278850bac5f1d