### PR TITLE
Add refresh-token handling via middleware and logout

### DIFF
--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -1,0 +1,57 @@
+"""Middleware for automatic token refresh using Cognito."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable, Awaitable
+
+from fastapi import Request, Response
+from jose import JWTError, jwt
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .cognito import refresh_access_token
+
+logger = logging.getLogger(__name__)
+
+
+class RefreshTokenMiddleware(BaseHTTPMiddleware):
+    """Refresh the access token on each request if needed."""
+
+    def __init__(self, app, max_age: int = 30 * 24 * 60 * 60) -> None:
+        super().__init__(app)
+        self.max_age = max_age
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        token = request.cookies.get("access_token")
+        refresh_token = request.cookies.get("refresh_token")
+        new_access: str | None = None
+
+        if token:
+            try:
+                claims = jwt.get_unverified_claims(token)
+                exp = int(claims.get("exp", 0))
+                if exp <= int(time.time()) and refresh_token:
+                    tokens = refresh_access_token(refresh_token)
+                    new_access = tokens.get("access_token")
+                    if new_access:
+                        token = new_access
+            except JWTError:
+                logger.error("Failed to parse JWT for refresh check")
+            except Exception:
+                logger.exception("Error refreshing token")
+
+        response = await call_next(request)
+        new_access = getattr(request.state, "new_access_token", new_access)
+        if new_access:
+            secure = request.url.scheme == "https"
+            response.set_cookie(
+                "access_token",
+                new_access,
+                httponly=True,
+                secure=secure,
+            )
+        return response
+

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -4,7 +4,7 @@ import logging
 from fastapi import APIRouter, Request, status
 from fastapi.responses import RedirectResponse, Response as FastAPIResponse
 
-from app.config import COGNITO_AUTH_URL
+from app.config import COGNITO_AUTH_URL, COGNITO_AUTH_URL_BASE, COGNITO_CLIENT_ID, COGNITO_REDIRECT_URI
 
 logger = logging.getLogger(__name__)
 
@@ -16,3 +16,16 @@ async def get_login(request: Request) -> FastAPIResponse:
     """Redirect directly to Cognito's hosted UI."""
     logger.debug("Redirecting to Cognito login; existing cookies: %r", dict(request.cookies))
     return RedirectResponse(url=COGNITO_AUTH_URL, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+@auth_router.get("/logout")
+async def logout(request: Request) -> FastAPIResponse:
+    """Clear session cookies and optionally redirect to Cognito."""
+    logout_url = COGNITO_AUTH_URL_BASE.replace("/login", "/logout")
+    logout_url += f"?client_id={COGNITO_CLIENT_ID}&logout_uri={COGNITO_REDIRECT_URI}"
+    resp = RedirectResponse(url=logout_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+    secure_flag = request.url.scheme == "https"
+    resp.delete_cookie("access_token", httponly=True, secure=secure_flag)
+    resp.delete_cookie("refresh_token", httponly=True, secure=secure_flag)
+    logger.debug("User logged out, cookies cleared")
+    return resp

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -166,8 +166,11 @@ def test_get_current_user_valid(monkeypatch):
         algorithm="HS256",
         headers={"kid": "test"},
     )
+    from starlette.requests import Request
+
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-    payload = dependencies.get_current_user(token=creds)
+    request = Request(scope={"type": "http", "headers": []})
+    payload = dependencies.get_current_user(request=request, token=creds)
     assert payload["sub"] == "u1"
 
 
@@ -198,6 +201,9 @@ def test_get_current_user_invalid(monkeypatch):
 
     token = jwt.encode({"sub": "u1", "aud": os.environ["COGNITO_CLIENT_ID"]},
                        "wrong", algorithm="HS256", headers={"kid": "test"})
+    from starlette.requests import Request
+
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    request = Request(scope={"type": "http", "headers": []})
     with pytest.raises(Exception):
-        dependencies.get_current_user(token=creds)
+        dependencies.get_current_user(request=request, token=creds)


### PR DESCRIPTION
## Summary
- use refresh tokens from Cognito
- refresh access tokens using middleware and dependency
- store refresh tokens in secure cookies
- support logout route to clear cookies
- adjust tests for new dependency signature

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc50e4d6c8331abdfca57ac469a1a