### PR TITLE
Add user settings page with API gateway calls

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,12 +3,17 @@
 from pathlib import Path
 
 import logging
+import os
+from typing import Any, Dict
+
+import requests
 from app.logger import configure_logging
-from fastapi import FastAPI, Request, status
+from fastapi import Depends, FastAPI, Form, Request, status
 from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.security import HTTPAuthorizationCredentials
 from app.auth.routes import auth_router
+from app.auth.dependencies import get_current_user
 from app.config import COGNITO_AUTH_URL
 from app.jinja2_env import templates
 from app.auth.cognito import exchange_code_for_tokens
@@ -19,6 +24,29 @@ REFRESH_TOKEN_MAX_AGE = 30 * 24 * 60 * 60  # 30 days
 configure_logging()
 
 logger = logging.getLogger(__name__)
+
+# API Gateway configuration
+AWS_REGION = os.getenv("AWS_REGION", "eu-west-2")
+API_GATEWAY_ID = os.getenv("API_GATEWAY_ID")
+
+def _api_base() -> str:
+    if not API_GATEWAY_ID:
+        raise RuntimeError("API_GATEWAY_ID environment variable is not set")
+    return f"https://{API_GATEWAY_ID}.execute-api.{AWS_REGION}.amazonaws.com"
+
+def fetch_user_settings(sub: str) -> Dict[str, Any]:
+    url = f"{_api_base()}/user/{sub}"
+    resp = requests.get(url, timeout=10)
+    if resp.status_code == 404:
+        return {}
+    resp.raise_for_status()
+    return resp.json()
+
+def save_user_settings(sub: str, nickname: str, preferred_class: str) -> None:
+    url = f"{_api_base()}/user/{sub}"
+    payload = {"nickname": nickname, "preferred_class": preferred_class}
+    resp = requests.post(url, json=payload, timeout=10)
+    resp.raise_for_status()
 
 # Determine this file’s parent dir (i.e. the "app/" folder)
 BASE_DIR = Path(__file__).parent
@@ -105,3 +133,35 @@ async def root(request: Request) -> Response:
 
     # No code, no creds → start login
     return RedirectResponse(COGNITO_AUTH_URL, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+@app.get("/settings", include_in_schema=False)
+async def get_settings(request: Request, user: Dict[str, Any] = Depends(get_current_user)) -> Response:
+    """Render the user settings form populated from API Gateway."""
+    settings = {}
+    try:
+        settings = fetch_user_settings(user["sub"])
+    except Exception:
+        logger.exception("Failed to fetch user settings")
+
+    return templates.TemplateResponse(
+        request,
+        "settings.html",
+        {"user": user, "settings": settings},
+    )
+
+
+@app.post("/settings", include_in_schema=False)
+async def post_settings(
+    request: Request,
+    nickname: str = Form(...),
+    preferred_class: str = Form(...),
+    user: Dict[str, Any] = Depends(get_current_user),
+) -> Response:
+    """Save settings via API Gateway then redirect back."""
+    try:
+        save_user_settings(user["sub"], nickname, preferred_class)
+    except Exception:
+        logger.exception("Failed to save user settings")
+
+    return RedirectResponse("/settings", status_code=status.HTTP_303_SEE_OTHER)

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -4,6 +4,9 @@
 
 {% block content %}
 {% if user %}
+<div class="flex justify-end p-2">
+    <a href="/settings" class="text-blue-600 underline">Settings</a>
+</div>
 <h1>Hello {{user.sub}}!</h1>
 <h1>user: {{user}} </h1>
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="max-w-md mx-auto bg-white p-4 mt-4 rounded shadow">
+    <h1 class="text-xl mb-4">User Settings</h1>
+    <form method="post">
+        <div class="mb-4">
+            <label for="nickname" class="block font-bold mb-1">User nickname</label>
+            <input type="text" id="nickname" name="nickname" maxlength="30" value="{{ settings.nickname or '' }}" class="w-full border rounded p-2" />
+        </div>
+        <div class="mb-4">
+            <label for="preferred_class" class="block font-bold mb-1">Preferred class to play</label>
+            <select id="preferred_class" name="preferred_class" class="w-full border rounded p-2">
+                <option value="reception" {% if settings.preferred_class == 'reception' %}selected{% endif %}>reception</option>
+                {% for n in range(1,7) %}
+                <option value="{{n}}" {% if settings.preferred_class == n|string %}selected{% endif %}>{{n}}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="text-right">
+            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import requests
 from fastapi.testclient import TestClient
 from fastapi.security import HTTPAuthorizationCredentials
 from jose import jwt
@@ -16,9 +17,18 @@ os.environ.setdefault("COGNITO_REDIRECT_URI", "http://testserver/")
 os.environ.setdefault("COGNITO_AUTH_URL_BASE", "https://example.com/login")
 os.environ.setdefault("COGNITO_SCOPE", "openid+profile")
 
+def _fake_get(url):
+    class Resp:
+        def json(self):
+            return {"keys": []}
+
+    return Resp()
+
+requests.get = _fake_get
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from app.main import app
-from app.config import COGNITO_AUTH_URL
+from app.main import app  # noqa: E402
+from app.config import COGNITO_AUTH_URL  # noqa: E402
 
 client = TestClient(app)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,30 @@
+import requests
+
+
+class Resp:
+    status_code = 200
+
+    def json(self):
+        return {"nickname": "nick", "preferred_class": "1"}
+
+    def raise_for_status(self):
+        pass
+
+requests.get = lambda url, timeout=10: Resp()
+
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+import app.main as app_main  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_settings_page(monkeypatch):
+    app.dependency_overrides[app_main.get_current_user] = (
+        lambda token=None, request=None: {"sub": "u1", "username": "u1", "attributes": {}}
+    )
+
+    resp = client.get("/settings", headers={"Authorization": "Bearer t"})
+    assert resp.status_code == 200
+    assert "User Settings" in resp.text
+    app.dependency_overrides = {}


### PR DESCRIPTION
## Summary
- add settings link on home page
- implement API Gateway calls for user settings
- create settings form template
- test new settings view

## Testing
- `poetry run ruff check .`
- `poetry run pytest`
- `npm run build:css` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_687802f28d788331bf2aa6d367a6bbea